### PR TITLE
AI-assisted: flat star mode, deterministic addressing, EIGRP template…

### DIFF
--- a/src/topogen/main.py
+++ b/src/topogen/main.py
@@ -99,6 +99,13 @@ def create_argparser():
         default="iosv",
     )
     parser.add_argument(
+        "--device-template",
+        dest="dev_template",
+        type=str,
+        default="iosv",
+        help='CML node definition to use for routers (e.g., iosv, iol, lxc). Defaults to "%(default)s"',
+    )
+    parser.add_argument(
         "--list-templates",
         dest="listtemplates",
         action="store_true",
@@ -107,9 +114,23 @@ def create_argparser():
     parser.add_argument(
         "-m",
         "--mode",
-        choices=("nx", "simple"),
+        choices=("nx", "simple", "flat"),
         default="simple",
         help='mode of operation, default is "%(default)s"',
+    )
+    parser.add_argument(
+        "--flat-group-size",
+        dest="flat_group_size",
+        type=int,
+        default=20,
+        help="Routers per unmanaged switch when using flat mode, default %(default)d",
+    )
+    parser.add_argument(
+        "--yaml",
+        dest="yaml_output",
+        metavar="FILE",
+        type=str,
+        help="Export the created lab to a YAML file at FILE",
     )
     parser.add_argument(
         "nodes",
@@ -174,8 +195,10 @@ def main():
         # argparse ensures correct mode
         if args.mode == "simple":
             retval = renderer.render_node_sequence()
-        else:  # args.mode == "nx":
+        elif args.mode == "nx":
             retval = renderer.render_node_network()
+        else:  # args.mode == "flat"
+            retval = renderer.render_flat_network()
     except TopogenError as exc:
         _LOGGER.error(exc)
         retval = 1

--- a/src/topogen/templates/iosv-eigrp.jinja2
+++ b/src/topogen/templates/iosv-eigrp.jinja2
@@ -23,15 +23,11 @@ ip route 0.0.0.0 0.0.0.0 {{ origin.ip }}
 int Loopback0
     ip address {{ node.loopback.ip }} {{ node.loopback.netmask }}
 !
-router ospf 1
+router eigrp 100
     passive-interface Loopback0
-    network {{ node.loopback.ip }} 0.0.0.0 area 0
-    {%- for iface in node.interfaces %}
-    network {{ iface.address.ip }} 0.0.0.0 area 0
-    {%- endfor %}
-    {%- if origin %}
-    default-information originate
-    {%- endif %}
+    network 10.10.0.0 0.0.255.255
+    network 10.20.0.0 0.0.255.255
+    no auto-summary
 !
 {%- for iface in node.interfaces %}
 interface GigabitEthernet0/{{ loop.index0 }}


### PR DESCRIPTION
…, YAML export hook, SSH v2/RSA-2048, console no-timeout, docs
Flat mode (star fabric with SWmgt0 core and access switches).
Gi0/0 10.10.C.D/16 and Loopback0 10.20.C.D/32 with router number encoding.
iosv-eigrp template (EIGRP 100), SSH v2 + RSA 2048, console exec-timeout 0 0.
Optional YAML export via controller; note that offline YAML could be a future enhancement.